### PR TITLE
Quote prettier glob invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "serve-debug": "nodemon --inspect dist/server.js",
         "watch-debug": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run serve-debug\"",
         "typecheck": "tsc --noEmit",
-        "run-prettier": "prettier src/*.ts",
+        "run-prettier": "prettier 'src/**/*.ts'",
         "validate-prettiness": "yarn run-prettier -c",
         "make-prettier": "yarn run-prettier --write"
     },


### PR DESCRIPTION
Uses recursive glob for `prettier` invocation.
Quotes glob so prettier handles glob expansion instead of shell.
https://github.com/prettier/prettier/issues/2078#issuecomment-307539076

Existing glob only expands to `src` and not sub-directories on zsh.

This change ensure prettier handles the expansion instead of leaving it to whichever shell is running. 
